### PR TITLE
Add reauthentication logic for Restforce client when token is expired

### DIFF
--- a/lib/salesforce_bulk_api.rb
+++ b/lib/salesforce_bulk_api.rb
@@ -13,7 +13,7 @@ module SalesforceBulkApi
   class Api
     attr_reader :connection
 
-    SALESFORCE_API_VERSION = '46.0'
+    SALESFORCE_API_VERSION = '57.0'
 
     def initialize(client)
       @connection = SalesforceBulkApi::Connection.new(SALESFORCE_API_VERSION, client)

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -52,12 +52,12 @@ module SalesforceBulkApi
         count :post
         throttle(http_method: :post, path: path)
         response = https(host).post(path, xml, headers)
-        raise if response.code == '401'
+
+        # try reauthenticating once
+        raise if response.code == '401' && !retried
 
         response.body
       rescue
-        raise if retried
-
         retried = true
         reauthenticate
         retry
@@ -76,12 +76,10 @@ module SalesforceBulkApi
         count :get
         throttle(http_method: :get, path: path)
         response = https(host).get(path, headers)
-        raise if response.code == '401'
+        raise if response.code == '401' && !retried
 
         response.body
       rescue
-        raise if retried
-
         retried = true
         reauthenticate
         retry

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -5,62 +5,87 @@ module SalesforceBulkApi
     include Concerns::Throttling
 
     LOGIN_HOST = 'login.salesforce.com'
+    RESTFORCE_CLIENT_TYPE = 'Restforce::Data::Client'
 
     def initialize(api_version, client)
       @client = client
       @api_version = api_version
       @path_prefix = "/services/async/#{@api_version}/"
 
-      login()
+      login
     end
 
-    def login()
-      client_type = @client.class.to_s
-      case client_type
-      when "Restforce::Data::Client"
+    def login
+      @client_type = @client.class.to_s
+
+      case @client_type
+      when RESTFORCE_CLIENT_TYPE
+        # authenticate the client if it's not already authenticated
+        @client.authenticate! if @client.options[:oauth_token].empty? || @client.options[:instance_url].empty?
+
         @session_id = @client.options[:oauth_token]
         @server_url = @client.options[:instance_url]
       else
         @session_id = @client.oauth_token
         @server_url = @client.instance_url
       end
-      @instance = parse_instance()
+
+      @instance = parse_instance
       @instance_host = "#{@instance}.salesforce.com"
     end
 
+    def reauthenticate
+      # currently only supports Restforce reauthentication
+      @client.authenticate! if @client_type == RESTFORCE_CLIENT_TYPE
+      login
+    end
+
     def post_xml(host, path, xml, headers)
-      host = host || @instance_host
-      if host != LOGIN_HOST # Not login, need to add session id to header
-        headers['X-SFDC-Session'] = @session_id
-        path = "#{@path_prefix}#{path}"
-      end
-      i = 0
+      retried = false
       begin
+        host = host || @instance_host
+        if host != LOGIN_HOST # Not login, need to add session id to header
+          headers['X-SFDC-Session'] = @session_id
+          path = "#{@path_prefix}#{path}"
+        end
+
         count :post
         throttle(http_method: :post, path: path)
-        https(host).post(path, xml, headers).body
+        response = https(host).post(path, xml, headers).body
+        raise if response.code == '401'
+
+        response
       rescue
-        i += 1
-        if i < 3
-          puts "Request fail #{i}: Retrying #{path}"
-          retry
-        else
-          puts "FATAL: Request to #{path} failed three times."
-          raise
-        end
+        raise if retried
+
+        retried = true
+        reauthenticate
+        retry
       end
     end
 
     def get_request(host, path, headers)
-      host = host || @instance_host
-      path = "#{@path_prefix}#{path}"
-      if host != LOGIN_HOST # Not login, need to add session id to header
-        headers['X-SFDC-Session'] = @session_id;
-      end
+      retried = false
+      begin
+        host = host || @instance_host
+        path = "#{@path_prefix}#{path}"
+        if host != LOGIN_HOST # Not login, need to add session id to header
+          headers['X-SFDC-Session'] = @session_id;
+        end
 
-      count :get
-      throttle(http_method: :get, path: path)
-      https(host).get(path, headers).body
+        count :get
+        throttle(http_method: :get, path: path)
+        response = https(host).get(path, headers).body
+        raise if response.code == '401'
+
+        response
+      rescue
+        raise if retried
+
+        retried = true
+        reauthenticate
+        retry
+      end
     end
 
     def https(host)
@@ -87,12 +112,10 @@ module SalesforceBulkApi
       get_counters[http_method] += 1
     end
 
-    def parse_instance()
+    def parse_instance
       @instance = @server_url.match(/https:\/\/[a-z]{2}[0-9]{1,2}\./).to_s.gsub("https://","").split(".")[0]
       @instance = @server_url.split(".salesforce.com")[0].split("://")[1] if @instance.nil? || @instance.empty?
       @instance
     end
-
   end
-
 end

--- a/lib/salesforce_bulk_api/connection.rb
+++ b/lib/salesforce_bulk_api/connection.rb
@@ -51,10 +51,10 @@ module SalesforceBulkApi
 
         count :post
         throttle(http_method: :post, path: path)
-        response = https(host).post(path, xml, headers).body
+        response = https(host).post(path, xml, headers)
         raise if response.code == '401'
 
-        response
+        response.body
       rescue
         raise if retried
 
@@ -75,10 +75,10 @@ module SalesforceBulkApi
 
         count :get
         throttle(http_method: :get, path: path)
-        response = https(host).get(path, headers).body
+        response = https(host).get(path, headers)
         raise if response.code == '401'
 
-        response
+        response.body
       rescue
         raise if retried
 


### PR DESCRIPTION
The original gem only scraped auth credentials from the Restforce client that was passed into it. That means if the token was expired, it doesn't benefit from the Restforce's ability to reauthenticate and try again. This fork and change are intended to fix that behavior, and reauthenticate the client if we get a 401 from salesforce.